### PR TITLE
Install assembly to Program Files as well as GAC

### DIFF
--- a/Installer/Installer/Product.wxs
+++ b/Installer/Installer/Product.wxs
@@ -15,18 +15,29 @@
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFilesFolder">
-        <Directory Id="INSTALLFOLDER" Name="FSharp.Compiler.CodeDom" />
+        <Directory Id="INSTALLFOLDER" Name="FSharp.Compiler.CodeDom">
+          <Directory Id="GAC" Name="GAC" />
+        </Directory>
       </Directory>
     </Directory>
 
+    <DirectoryRef Id="GAC">
+      <Component Id="RT_FSharpCompilerCodeDom"
+           Guid="17FC7800-C54C-497C-805E-3D645211D1E6">
+        <File Id="F_RT_FSharpCompilerCodeDom"
+              Name="FSharp.Compiler.CodeDom.dll"
+              Source="..\..\bin\FSharp.Compiler.CodeDom.dll"
+              KeyPath="yes"
+              Assembly=".net" />
+      </Component>
+    </DirectoryRef>
     <DirectoryRef Id="INSTALLFOLDER">
       <Component Id="DT_FSharpCompilerCodeDom"
                  Guid="AC80FBA4-B7C0-4CAF-AFC1-0ABF7B0A9772">
         <File Id="F_DT_FSharpCompilerCodeDom"
               Name="FSharp.Compiler.CodeDom.dll"
               Source="..\..\bin\FSharp.Compiler.CodeDom.dll"
-              KeyPath="yes"
-              Assembly=".net" />
+              KeyPath="yes" />
         <RegistryKey Root="HKLM"
                      Key="SOFTWARE\Microsoft\.NETFramework\v4.0.30319\AssemblyFoldersEx\[ProductName]">
           <RegistryValue Value="[$DT_FSharpCompilerCodeDom]"
@@ -36,6 +47,7 @@
     </DirectoryRef>
 
     <Feature Id="ProductFeature" Title="FSharp.Compiler.CodeDom" Level="1">
+      <ComponentRef Id="RT_FSharpCompilerCodeDom" />
       <ComponentRef Id="DT_FSharpCompilerCodeDom" />
     </Feature>
 
@@ -44,7 +56,7 @@
 
     <CustomAction Id="AssignAssemblyName"
                   Property="ASSEMBLYNAME"
-                  Value="FSharp.Compiler.CodeDom.FSharpCodeProvider, !(bind.AssemblyFullName.F_DT_FSharpCompilerCodeDom)" />
+                  Value="FSharp.Compiler.CodeDom.FSharpCodeProvider, !(bind.AssemblyFullName.F_RT_FSharpCompilerCodeDom)" />
 
     <CustomAction Id="SetCustomActionDataValue"
                   Property="AddToMachineConfig"


### PR DESCRIPTION
We have to specify the component twice: once to get a copy registered in
the GAC, and again so that we can install a copy of the assembly to
Program Files.  The former is for the .NET runtime's use and is required
because we also register it as a CodeDom provider, and the latter is for
the benefit of developers so that the assembly shows up in the VS "add
reference" window.