### PR TITLE
Replace FSharpOption with Option when emitting F#

### DIFF
--- a/src/FSharp.Compiler.CodeDom/CodeGenerator.fs
+++ b/src/FSharp.Compiler.CodeDom/CodeGenerator.fs
@@ -445,8 +445,14 @@ and getBaseTypeRef (cr:CodeTypeReference) renames (ns:string) (tyParams:Set<stri
                   i <- i + 1
       | _ -> sb.Append(c) |> ignore
     i <- i + 1
+
   // generate type arguments
-  sb.Append(getTypeArgs cr.TypeArguments renames ns tyParams fsSyntax).ToString()
+  let gta = getTypeArgs cr.TypeArguments renames ns tyParams fsSyntax
+
+  // Check for standard F# generic types
+  match sb.ToString() with
+            | "Microsoft.FSharp.Core.FSharpOption" -> "Option" + gta
+            | _ -> sb.Append(gta) |> fun x -> x.ToString()
 
 /// Generate type reference with empty context
 and getBaseTypeRefString (s:string) =


### PR DESCRIPTION
Fixes #19 

This fixes my problem of wanting to create code from C# with option types. If it's not quite the right way to do this I'm open to other suggestions :)