### PR TITLE
Update tutorial to add instructions to build the MSI installer.

### DIFF
--- a/docs/content/tutorial.fsx
+++ b/docs/content/tutorial.fsx
@@ -14,7 +14,7 @@ Windows) or write permission to the Mono GAC and `machine.config` file (on
 Unix).  A system-wide install can coexist with individual NuGet installs.
 
 To perform a system-wide install on Windows, build the library from the command
-line with `build Release`.  A MSI package will be produced in
+line with `build Release --build-installer`.  A MSI package will be produced in
 `Installer\Installer\bin\Release`.  After installation, the library will be
 available for use.
 


### PR DESCRIPTION
Update the tutorial to conform to the change made in commit 5e5a2b3047b0fcbaca75a027d3b5b4a383b9ddb4 "Don't build installers by default" by @drvink who committed on Apr 4, 2016.